### PR TITLE
Ease inclusion of themes, plugins, and uploads

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,7 @@ if [[ $DB_CONNECTABLE -eq 0 ]]; then
             echo "Cannot create database for wordpress"
             exit RET
         fi
-        echo "=> Done!"    
+        echo "=> Done!"
     else
         echo "=> Skipped creation of database $DB_NAME – it already exists."
     fi
@@ -49,6 +49,10 @@ else
     echo "Cannot connect to Mysql"
     exit $DB_CONNECTABLE
 fi
+
+ln -sf /opt/wordpress/themes/* /app/wp-content/themes/
+ln -sf /opt/wordpress/plugins/* /app/wp-content/plugins/
+ln -sf /opt/wordpress/uploads/* /app/wp-content/uploads/
 
 touch /.mysql_db_created
 exec supervisord -n


### PR DESCRIPTION
With the boot2docker images compiled with Virtualbox guest additions enabled, [link (medium.com)](https://medium.com/boot2docker-lightweight-linux-for-docker/boot2docker-together-with-virtualbox-guest-additions-da1e3ab2465c), it is possible to include file syncing from the host computer to the boot2docker vm. In my case, this is a guest addition from `/Users/<my-username>/dev/` -> `/Users`, but this can be configured to the users preference.

From there, you can do a `-v "/Users/<path-to-directory-with-optional-subdirectories-themes-plugins-uploads>":/opt` to include these files in a data container, for example `docker run -d -v "/Users/testing":/opt --name theme_vol busybox`. Then when you run the wordpress-stackable container, you would do the `--volumes-from theme_vol` to get those files into the wordpress container, which would then create the symbolic links into the /app directory to allow those files to be edited inside the container live. This seems like a pretty solid wordpress developer environment to me, so I'm opening this pull request to make this change to this image so I don't need to rebuild the image from a fork each time I want to use it. If you all think this is acceptable then I can take a stab at updating the documentation as well.
