### PR TITLE
Adds chown to wp-content before starting wp

### DIFF
--- a/run-wordpress.sh
+++ b/run-wordpress.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+chown www-data:www-data /app/wp-content -R
+
 if [ -f /.mysql_db_created ]; then
         exec /run.sh
         exit 1


### PR DESCRIPTION
It could be nice feature to chown `wp-content` before starting wordpress. I need this as I mount the volume with `docker run -v /myfolder:/app/wp-content wordpress`.

Thanks!
