### PR TITLE
Support run at a subpath. One level only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV DB_PORT **LinkMe**
 ENV DB_NAME wordpress
 ENV DB_USER admin
 ENV DB_PASS **ChangeMe**
+ENV ROOT_PATH /
 
 EXPOSE 80
 VOLUME ["/app/wp-content"]

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+if [ "$ROOT_PATH" != "/" ]
+then
+    unlink /var/www/html
+    mkdir /var/www/html
+    ln -s /app /var/www/html/$ROOT_PATH
+fi
 
 chown www-data:www-data /app -R
 chmod -R 777 /app/wp-content


### PR DESCRIPTION
Sometimes we want to run wordpress under /blog or /wordpress , etc.