### PR TITLE
Add .htaccess so permlink works when restart container.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,11 @@
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+
+# END WordPress

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
 
 RUN sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
 RUN a2enmod rewrite
+ADD .htaccess /app/.htaccess
 ADD wp-config.php /app/wp-config.php
 ADD run.sh /run.sh
 RUN chmod +x /*.sh


### PR DESCRIPTION
When for any reason that the container was restarted, the permlink does not work until you visit the url /wp-admin/options-permalink.php
I inspected the code and turns out it just generate a .htaccess file.
Add this file ensure that the permlink works from the beginning.